### PR TITLE
FIX: refer with full path to benchmark

### DIFF
--- a/config/samples/perf_v1alpha1_fio.yaml
+++ b/config/samples/perf_v1alpha1_fio.yaml
@@ -4,5 +4,5 @@ metadata:
   name: fio-sample
 spec:
   jobFiles:
-   - jobs/rand-read.fio
-   - jobs/rand-write.fio
+   - /jobs/rand-read.fio
+   - /jobs/rand-write.fio


### PR DESCRIPTION
Change in docker image (https://github.com/xridge/fio-docker/pull/2) requires that we specify the full path of the job files from now.