### PR TITLE
FIX: Add license header to controllers/fio/suite_test.go

### DIFF
--- a/controllers/fio/suite_test.go
+++ b/controllers/fio/suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The xridge kubestone contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fio
 
 import (


### PR DESCRIPTION
#46 missed one licensing header, here comes the fix!