### PR TITLE
FIX: Removed build step from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,5 @@
 version: 2
 jobs:
-  build:
-    docker:
-      - image: alpine:3.10.1
-    steps:
-      - run:
-          name: Dummy job to satisfy github
-          command: |
-            echo "Hello GitHub!"
-
   run_unit_tests:
     docker:
       - image: circleci/golang:1.12.5
@@ -68,6 +59,5 @@ workflows:
   version: 2
   test:
     jobs:
-      - build
       - run_unit_tests
       - run_e2e_tests


### PR DESCRIPTION
Also modified GitHub's branch protection rules accordingly: 
now the docker build, and circle's 'run_unit_tests' and 'run_e2e_tests' are mandatory.