### PR TITLE
TST: Increase iperf3 e2e timeout to 90sec

### DIFF
--- a/tests/e2e/iperf3_test.go
+++ b/tests/e2e/iperf3_test.go
@@ -49,7 +49,7 @@ var _ = Describe("end to end test", func() {
 
 		Context("created job", func() {
 			It("Should finish in a pre-defined time", func() {
-				timeout := 60
+				timeout := 90
 				cr := &v1alpha1.Iperf3{}
 				// TODO: find the respective objects via the CR owner reference
 				namespacedName := types.NamespacedName{


### PR DESCRIPTION
end to end tests sometimes ran into timeout in iperf.