### PR TITLE
Fixes iperf3 cmdLineArgs bug for server deployment

### DIFF
--- a/controllers/iperf3/clientjob_test.go
+++ b/controllers/iperf3/clientjob_test.go
@@ -64,6 +64,13 @@ var _ = Describe("Client Pod", func() {
 			})
 		})
 
+		Context("with cmdLineArgs specified", func() {
+			It("--testing mode is set", func() {
+				Expect(job.Spec.Template.Spec.Containers[0].Args).To(
+					ContainElement("--testing"))
+			})
+		})
+
 		Context("with UDP mode specified", func() {
 			cr.Spec.UDP = true
 			job := NewClientJob(&cr)

--- a/controllers/iperf3/serverdeployment.go
+++ b/controllers/iperf3/serverdeployment.go
@@ -64,7 +64,7 @@ func NewServerDeployment(cr *perfv1alpha1.Iperf3) *appsv1.Deployment {
 	}
 
 	iperfCmdLineArgs = append(iperfCmdLineArgs,
-		qsplit.ToStrings([]byte(cr.Spec.ClientConfiguration.CmdLineArgs))...)
+		qsplit.ToStrings([]byte(cr.Spec.ServerConfiguration.CmdLineArgs))...)
 
 	// Iperf3 Server does not like if probe connections are made to the port,
 	// therefore we are checking if the port if open or not via shell script

--- a/controllers/iperf3/serverdeployment_test.go
+++ b/controllers/iperf3/serverdeployment_test.go
@@ -136,6 +136,13 @@ var _ = Describe("Server Deployment", func() {
 			})
 		})
 
+		Context("with cmdLineArgs specified", func() {
+			It("--testing mode is set", func() {
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(
+					ContainElement("--testing"))
+			})
+		})
+
 		Context("with podLabels specified", func() {
 			It("should contain all podLabels", func() {
 				for k, v := range cr.Spec.ServerConfiguration.PodLabels {


### PR DESCRIPTION
The server deployment was incorrectly using the client cmdLineArgs.