### PR TITLE
FIX: Limit the number of processes to 8 so that we don't run out of memory in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: circleci/golang:1.12.5
         environment:
           GO111MODULE: "on"
+          GOFLAGS: "-p=8"  # To avoid out of memory related kills
 
     working_directory: /go/src/github.com/xridge/kubestone
     steps:


### PR DESCRIPTION
For reference see this:
https://github.com/golang/go/issues/26186