### PR TITLE
Update quickstart to reference current release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ API_VERSION ?= "v1alpha1"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Get the last release tag if an override is not provided
+KUBESTONE_RELEASE ?= $(shell git tag -l | egrep "v\d+\.\d+\.\d+" | tail -1)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -110,3 +113,5 @@ endif
 
 # All the things needed before you make a PR
 pre-commit: generate apidocs manifests fmt vet
+	@echo "Updating quickstart doc to current release ${KUBESTONE_RELEASE}"
+	sed -i'' -E "s@(github\.com/xridge/kubestone/config/default)(\?ref=v\d+\.\d+\.\d+)?\b@\1?ref=${KUBESTONE_RELEASE}@g" docs/quickstart.md

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,7 +25,7 @@ This guide will walk you through on the one the installation process and will sh
 Deploy Kubestone to `kubestone-system` namespace with the following command:
 
 ```bash
-$ kustomize build github.com/xridge/kubestone/config/default | kubectl create -f -
+$ kustomize build github.com/xridge/kubestone/config/default?ref=v0.5.0 | kubectl create -f -
 ```
 
 


### PR DESCRIPTION
bad news: our docs refers to installation steps with ‘latest’ image. if someone’s pod restarts and we add new CRD to the mix it’ll fail with:
```
2020-04-19T05:49:56.138Z	INFO	controller-runtime.controller	Starting EventSource	{"controller": "qperf", "source": "kind source: /, Kind="}
2020-04-19T05:49:56.139Z	INFO	controller-runtime.controller	Starting EventSource	{"controller": "ycsbbench", "source": "kind source: /, Kind="}
2020-04-19T05:49:56.139Z	ERROR	controller-runtime.source	if kind is a CRD, it should be installed before calling Start	{"kind": "YcsbBench.perf.kubestone.xridge.io", "error": "no matches for kind \"YcsbBench\" in version \"perf.kubestone.xridge.io/v1alpha1\""}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/source/source.go:88
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Watch
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/builder.(*Builder).doWatch
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/builder/controller.go:162
sigs.k8s.io/controller-runtime/pkg/builder.(*Builder).Build
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/builder/controller.go:151
sigs.k8s.io/controller-runtime/pkg/builder.(*Builder).Complete
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/builder/controller.go:129
github.com/xridge/kubestone/controllers/ycsbbench.(*Reconciler).SetupWithManager
	/workspace/controllers/ycsbbench/controller.go:92
main.main
	/workspace/main.go:141
runtime.main
	/usr/local/go/src/runtime/proc.go:200
2020-04-19T05:49:56.139Z	ERROR	setup	unable to create controller	{"controller": "YcsbBench", "error": "no matches for kind \"YcsbBench\" in version \"perf.kubestone.xridge.io/v1alpha1\""}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
main.main
	/workspace/main.go:142
runtime.main
	/usr/local/go/src/runtime/proc.go:200
```