### PR TITLE
removed the UDP option from the server cmd args

### DIFF
--- a/controllers/iperf3/serverdeployment.go
+++ b/controllers/iperf3/serverdeployment.go
@@ -59,7 +59,6 @@ func NewServerDeployment(cr *perfv1alpha1.Iperf3) *appsv1.Deployment {
 
 	protocol := corev1.Protocol(corev1.ProtocolTCP)
 	if cr.Spec.UDP {
-		iperfCmdLineArgs = append(iperfCmdLineArgs, "--udp")
 		protocol = corev1.Protocol(corev1.ProtocolUDP)
 	}
 


### PR DESCRIPTION
Creating a udp iperf3 with this operator was failing due to the cmd option added to the server-side as well `--udp`

Verify by checking the official docs as well: https://iperf.fr/iperf-doc.php

![image](https://user-images.githubusercontent.com/9026451/105321713-1a6efc00-5bc8-11eb-9ad6-8cf098bc77b3.png)
